### PR TITLE
Make the HTTP async with asyncio.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
         - $HOME/.cache/pip/
 
 python:
-    - 3.5
     - 3.6
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,11 @@ cache:
         - $HOME/.cache/pip/
 
 python:
-    - 2.7
-    - 3.4
     - 3.5
     - 3.6
 
 install:
-    - pip install pytest coverage requests cryptography flake8
+    - pip install pytest coverage aiohttp cryptography flake8
 
 script:
     - coverage run -m pytest

--- a/validator.py
+++ b/validator.py
@@ -271,7 +271,6 @@ class X509Validator(object):
 
     def validate(self, cert, ctx):
         loop = asyncio.new_event_loop()
-        loop.set_debug(True)
         return loop.run_until_complete(
             _async_validate(self._roots, cert, ctx, loop)
         )


### PR DESCRIPTION
The good news is now we are async (though I've maintained the public API being synchronous for now).

The bad news is that this drops python2, emits some warnings which I'm failing to diagnose, and looking at the asyncio internals, appears to monkeypatch some global state so god only knows if this seemingly stateless code is really thread-safe.